### PR TITLE
Changed Azure App Services to Azure App Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Azure App Services & SQL Database ハンズオン
+# Azure App Service & SQL Database ハンズオン
 
-このリポジトリは、Azure App Services と SQL Database を使用した ASP.NET Core Web アプリケーションのハンズオン用に作成されたものです。
+このリポジトリは、Azure App Service と SQL Database を使用した ASP.NET Core Web アプリケーションのハンズオン用に作成されたものです。
 
 ハンズオンドキュメントは [こちら](docs/README.md) をご覧ください。
 
@@ -8,7 +8,7 @@
 - **アプリケーション概要**: タスク管理アプリケーション
 - **使用技術**: ASP.NET Core 9.0, Entity Framework Core 9.0, SQL Server
 - **データベース**: SQL Server
-- **デプロイ先**: Azure App Services
+- **デプロイ先**: Azure App Service
 - **データベース接続**: Azure SQL Database
 - **CI/CD**: GitHub Actions
 - **作成年月**: 2025年4月 
@@ -16,7 +16,7 @@
 # MyToDoAppSQL ソフトウェア内部仕様書
 
 ## 1. システム概要
-MyToDoAppSQL は ASP.NET Core 9.0 と Microsoft SQL Server（Entity Framework Core）を用いたシンプルな ToDo 管理Webアプリケーションです。タスク（ToDo）の登録・編集・削除・詳細表示が可能です。
+MyToDoAppSQL は ASP.NET Core 9.0 と Microsoft SQL Server（Entity Framework Core）を用いたシンプルな ToDo 管理 Web アプリケーションです。タスク（ToDo）の登録・編集・削除・詳細表示が可能です。
 
 ## 2. アーキテクチャ構成
 - **フレームワーク**: ASP.NET Core 9.0

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,10 @@
-# Azure App Services & SQL Database ハンズオン
+# Azure App Service & SQL Database ハンズオン
 
 ⏲️ _Est. time to complete: 60 - 90 min._ ⏲️
 
 ## 目次
 
-- [Azure App Services \& SQL Database ハンズオン](#azure-app-services--sql-database-ハンズオン)
+- [Azure App Service \& SQL Database ハンズオン](#azure-app-service--sql-database-ハンズオン)
   - [目次](#目次)
   - [本ハンズオンで学べること 🎯](#本ハンズオンで学べること-)
   - [アプリケーション概要](#アプリケーション概要)
@@ -23,11 +23,11 @@
 
 ## 本ハンズオンで学べること 🎯
 
-- Azure App Services と SQL Database の概要
-  - Azure App Services の作成
+- Azure App Service と SQL Database の概要
+  - Azure App Service の作成
   - SQL Database の作成
   - SQL Database の接続文字列の確認と更新
-  - Azure App Services へのデプロイ
+  - Azure App Service へのデプロイ
   - デプロイ スロットの作成
   - デプロイ スロットの切り替え
   - GitHub Actions を使用した CI/CD の実行
@@ -162,7 +162,7 @@
 
 ## デプロイ スロットを利用したアプリケーションの更新
 
-ここまでの手順で、Azure App Services と SQL データベースを使用した .NET アプリケーションのデプロイが完了しました。次に、デプロイ スロットを利用して、アプリケーションの更新を行います。
+ここまでの手順で、Azure App Service と SQL データベースを使用した .NET アプリケーションのデプロイが完了しました。次に、デプロイ スロットを利用して、アプリケーションの更新を行います。
 デプロイ スロットを使用すると、アプリケーションの新しいバージョンを開発/テスト環境で確認してから、本番環境に切り替えることができます。これにより、アプリケーションの可用性を高めることができます。
 
 ### デプロイ スロットの作成
@@ -224,8 +224,8 @@
 
 ## まとめ
 
-以上で、Azure App Services と SQL データベースを使用した .NET アプリケーションのデプロイが完了しました。GitHub Actions を使用して、アプリケーションのビルドとデプロイを自動化する方法についても学びました。
-今後は、GitHub Copilot を使用して、アプリケーションの機能を追加したり、デザインを変更したりすることができます。また、Azure App Services のデプロイ スロットを利用して、アプリケーションの更新を行うこともできます。これにより、アプリケーションの可用性を高めることができます。さらには、Azure の他のサービスを組み合わせて、より高度なアプリケーションを構築することも可能です。例えば、Azure Functions を使用してサーバーレスアーキテクチャを実現したり、Azure Cosmos DB を使用して分散データベースを構築したりすることができます。
+以上で、Azure App Service と SQL データベースを使用した .NET アプリケーションのデプロイが完了しました。GitHub Actions を使用して、アプリケーションのビルドとデプロイを自動化する方法についても学びました。
+今後は、GitHub Copilot を使用して、アプリケーションの機能を追加したり、デザインを変更したりすることができます。また、Azure App Service のデプロイ スロットを利用して、アプリケーションの更新を行うこともできます。これにより、アプリケーションの可用性を高めることができます。さらには、Azure の他のサービスを組み合わせて、より高度なアプリケーションを構築することも可能です。例えば、Azure Functions を使用してサーバーレスアーキテクチャを実現したり、Azure Cosmos DB を使用して分散データベースを構築したりすることができます。
 ぜひ、Azure のサービスを活用して、より高度なアプリケーションを構築してみてください。
 
 おつかれさまでした！


### PR DESCRIPTION
This pull request updates references to "Azure App Services" by standardizing the terminology to "Azure App Service" across the documentation for consistency and accuracy. The changes span the `README.md` and `docs/README.md` files.

### Standardization of terminology:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R11): Updated "Azure App Services" to "Azure App Service" in the project description and deployment details.
* [`docs/README.md`](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L1-R7): Standardized "Azure App Services" to "Azure App Service" in the document title, table of contents, and throughout the content, including sections on deployment and application updates. [[1]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L1-R7) [[2]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L26-R30) [[3]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L165-R165) [[4]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L227-R228)